### PR TITLE
Fix cmd+b binding for emacs.cursorWordLeft

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
             },
             {
                 "key": "alt+b",
-                "mac": "cmd+f",
+                "mac": "cmd+b",
                 "command": "emacs.cursorWordLeft",
                 "when": "editorTextFocus"
             },


### PR DESCRIPTION
cmd+f -> cmd+b