### PR TITLE
Fix typo for CursorWordRight for MacOS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
             },
             {
                 "key": "alt+b",
-                "mac": "cmd+f",
+                "mac": "cmd+b",
                 "command": "emacs.cursorWordLeft",
                 "when": "editorTextFocus"
             },


### PR DESCRIPTION
Instead of 'cmd+b', it was set to 'cmd+f' for MacOS.